### PR TITLE
Bugfix - Changing start script for dev/prod environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "yarn test:unit && google-chrome ./coverage/index.html",
     "start": "yarn start:dev",
     "start:local": "yarn build:tsoa && yarn env:local ts-node-dev --respawn ./src",
-    "start:dev": "yarn build:tsoa && yarn env:dev ts-node-dev --respawn ./src",
+    "start:dev": "yarn build:tsoa && yarn env:dev node -r ts-node/register ./src/index.ts",
     "build": "yarn build:prod",
     "build:routes": "tsoa routes",
     "build:swagger": "tsoa swagger --basePath /service",

--- a/src/config/Logger.ts
+++ b/src/config/Logger.ts
@@ -1,21 +1,25 @@
-import constants from './constants';
-import * as logger from 'winston';
+import constants from "./constants";
+import * as logger from "winston";
 
 const date = new Date();
 const fileName = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}.log`;
 logger.configure({
-  level: 'debug',
+  level: "debug",
   format: logger.format.combine(
     logger.format.colorize(),
-    logger.format.simple()),
+    logger.format.simple()
+  ),
   transports: [
-    new logger.transports.File({ filename: `logs/${fileName}`, level: 'debug' }),
+    new logger.transports.File({
+      filename: `logs/${fileName}`,
+      level: "debug"
+    }),
     new logger.transports.Console()
   ]
 });
 
 export class Logger {
-  public static readonly shouldLog: boolean = constants.environment !== 'test';
+  public static readonly shouldLog: boolean = constants.environment !== "test";
   public static readonly console = logger;
 
   public static log(...args: any[]): void {
@@ -42,5 +46,4 @@ export class Logger {
     if (args.length <= 1) args = args[0];
     return JSON.stringify(args, null, 4);
   }
-
 }

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -37,7 +37,7 @@ export class UserController extends Controller {
     @Query("field") field?: string,
     @Query("filter") filter?: string
   ): Promise<IPaginationDto> {
-    return this.service.getPaginated({page, limit, sort, field, filter});
+    return this.service.getPaginated({ page, limit, sort, field, filter });
   }
 
   @Response(400, "Bad request")


### PR DESCRIPTION
## Background
We were facing an issue in dev and prod environments when an uncaughtException or an unhandledRejection occurs. The issue was that we were starting the app with ts-node-dev as a child process, so when the unhandled exception occurs the main thread was being killed but the app was hanging as there were some child processes still listening for changes. ts-node-dev is not required for dev and production environments.
## Changes done
- Changed app start script

